### PR TITLE
Fix premature class loading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.7'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.11'
     }
 }
 

--- a/src/main/java/pl/asie/foamfix/bugfixmod/coremod/BugfixModClassTransformer.java
+++ b/src/main/java/pl/asie/foamfix/bugfixmod/coremod/BugfixModClassTransformer.java
@@ -182,23 +182,8 @@ public class BugfixModClassTransformer implements IClassTransformer {
             hasInit = true;
 
             if (settings.mc18SkinSupport) {
-                try {
-                    Class c = Class.forName("com.unascribed.ears.Ears");
-                    settings.helloMmcg = false;
-                } catch (Throwable t) {
-                    settings.helloMmcg = true;
-                }
-            } else {
-                settings.helloMmcg = false;
-            }
-
-            if (settings.helloMmcg) {
-                try {
-                    Class c = Class.forName("api.player.render.RenderPlayerAPI");
-                    settings.helloMmcg = false;
-                } catch (Throwable t) {
-                    // pass
-                }
+                settings.helloMmcg = BugfixModClassTransformer.class.getResource("/com/unascribed/ears/Ears.class") == null
+                        && BugfixModClassTransformer.class.getResource("/api/player/render/RenderPlayerAPI.class") == null;
             }
         }
     }


### PR DESCRIPTION
The mod was unnecessarily loading classes when checking for their existence. This caused them to get loaded earlier than normal, and as a result, mixins in the DEFAULT environment targetting ModelBase, ModelBiped, ImageBufferDownload or IImageBuffer failed to get applied.

Fixes https://github.com/Roadhog360/Et-Futurum-Requiem/issues/249