### PR TITLE
Lwjgl3ify/Java 9+ compatibility

### DIFF
--- a/src/main/java/pl/asie/foamfix/FoamFixMod.java
+++ b/src/main/java/pl/asie/foamfix/FoamFixMod.java
@@ -57,8 +57,13 @@ public class FoamFixMod {
     public void preinit(FMLPreInitializationEvent evt) {
         logger = evt.getModLog();
 
-        System.out.println( System.getProperty("sun.boot.class.path"));
-        System.out.println(Arrays.toString(((URLClassLoader) ClassLoader.getSystemClassLoader()).getURLs()));
+        System.out.println(System.getProperty("sun.boot.class.path"));
+        final ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
+        if (systemClassLoader instanceof URLClassLoader) {
+            System.out.println(Arrays.toString(((URLClassLoader) systemClassLoader).getURLs()));
+        } else {
+            System.out.println(System.getProperty("java.class.path"));
+        }
 
         if (BugfixModClassTransformer.instance.settings.ArrowDingTweakEnabled) {
             ArrowDingTweakEventHandler handler = new ArrowDingTweakEventHandler();


### PR DESCRIPTION
The system class loader in java 9+ is no longer a URLClassLoader, as a fallback we can log `java.class.path` (the downside is it might not get updated with runtime classpath injections). This is the only issue stopping foamfix from working with lwjgl3ify.